### PR TITLE
Made cron friendly by using absolute paths

### DIFF
--- a/gcal/create_events.py
+++ b/gcal/create_events.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import datetime
+import pathlib
 import pickle
 import os.path
 from datetime import datetime
@@ -12,23 +13,24 @@ from typing import List
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
-def create_service():
+def create_service(creds_dir: pathlib.PosixPath):
     creds = None
     # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists("token.pickle"):
-        with open("token.pickle", "rb") as token:
+    token_fl = creds_dir / "token.pickle"
+    if os.path.exists(token_fl):
+        with open(token_fl, "rb") as token:
             creds = pickle.load(token)
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+            flow = InstalledAppFlow.from_client_secrets_file(creds_dir / "credentials.json", SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open("token.pickle", "wb") as token:
+        with open(token_fl, "wb") as token:
             pickle.dump(creds, token)
 
     return build("calendar", "v3", credentials=creds)
@@ -39,6 +41,7 @@ def create_event(
     start_time: datetime,
     end_time: datetime,
     guest_emails: List[str],
+    creds_dir: pathlib.PosixPath,
     description: str = "Automatically created event",
     google_meet: str = "",
 ):
@@ -62,7 +65,7 @@ def create_event(
         "attendees": [{"email": email, "optional": True} for email in guest_emails],
     }
     created_event = (
-        create_service().events().insert(calendarId="primary", body=event).execute()
+        create_service(creds_dir=creds_dir).events().insert(calendarId="primary", body=event).execute()
     )
     print(f"Event created: {(created_event.get('htmlLink'))}")
 

--- a/gcal/create_events.py
+++ b/gcal/create_events.py
@@ -27,7 +27,9 @@ def create_service(creds_dir: pathlib.PosixPath):
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(creds_dir / "credentials.json", SCOPES)
+            flow = InstalledAppFlow.from_client_secrets_file(
+                creds_dir / "credentials.json", SCOPES
+            )
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open(token_fl, "wb") as token:
@@ -65,7 +67,10 @@ def create_event(
         "attendees": [{"email": email, "optional": True} for email in guest_emails],
     }
     created_event = (
-        create_service(creds_dir=creds_dir).events().insert(calendarId="primary", body=event).execute()
+        create_service(creds_dir=creds_dir)
+        .events()
+        .insert(calendarId="primary", body=event)
+        .execute()
     )
     print(f"Event created: {(created_event.get('htmlLink'))}")
 

--- a/generate_watercoolers.py
+++ b/generate_watercoolers.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 import os
+import pathlib
 import random
 import yaml
 import sys
@@ -16,21 +17,28 @@ from gcal.create_events import create_event
 
 
 def generate_watercoolers():
+    script_dir = pathlib.Path(__file__).parent.absolute()
     # Load user_groups and generate watercoolers
-    USER_GROUPS_DIRECTORY = "user_groups"
+    user_groups_directory =  script_dir / "user_groups"
     all_files = [
-        os.path.join(USER_GROUPS_DIRECTORY, f)
-        for f in os.listdir(USER_GROUPS_DIRECTORY)
+        os.path.join(user_groups_directory, f)
+        for f in os.listdir(user_groups_directory)
     ]
     yaml_files = [f for f in all_files if os.path.isfile(f) and f.endswith(".yaml")]
     for yaml_file in yaml_files:
         print(colored(f"Reading file {yaml_file}...", "magenta"))
-        generate_watercoolers_for_user_group(yaml_file)
+        generate_watercoolers_for_user_group(
+            user_group_file_name=yaml_file,
+            script_dir=script_dir,
+        )
 
 
-def generate_watercoolers_for_user_group(user_group_file_name: str):
+def generate_watercoolers_for_user_group(
+    user_group_file_name: str,
+    script_dir: pathlib.PosixPath,
+):
     # Load topics
-    with open("topics.txt", "r") as topics_file:
+    with open(script_dir / "topics.txt", "r") as topics_file:
         all_topics = list(
             map(str.strip, filter(lambda x: x, topics_file.read().split("TOPIC_BEGIN")))
         )
@@ -72,6 +80,7 @@ def generate_watercoolers_for_user_group(user_group_file_name: str):
                     "guest_emails": users_in_watercooler,
                     "description": f"Watercooler topic:\n{chosen_topics[i]}",
                     "google_meet": gmeets[i],
+                    "creds_dir": script_dir,
                 }
             )
 

--- a/generate_watercoolers.py
+++ b/generate_watercoolers.py
@@ -19,7 +19,7 @@ from gcal.create_events import create_event
 def generate_watercoolers():
     script_dir = pathlib.Path(__file__).parent.absolute()
     # Load user_groups and generate watercoolers
-    user_groups_directory =  script_dir / "user_groups"
+    user_groups_directory = script_dir / "user_groups"
     all_files = [
         os.path.join(user_groups_directory, f)
         for f in os.listdir(user_groups_directory)


### PR DESCRIPTION
## Context

Cron requires absolute paths to be used everywhere. The previous version of the script looked up the locations of
- credentials.json
- token.pickle
- topics.txt
- user_groups/

using relative paths.

## Test
Tested by running the batch on CRON.
``` bash
0 5 * * MON /home/venv3/bin/python /home/tmp/watercooler/generate_watercoolers.py
```


