### PR TITLE
Converted create_events.py into an auth token creation  script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,27 @@
 A script to automate watercooler event creation in Google Calendar.
 
 ## How to run?
-- Make sure to follow steps described [here](https://developers.google.com/calendar/quickstart/python) to be able to use Google Calendar API. I recommend using your personal gmail account for this script.
+- Generate and save authorisation tokens for Google Calendar API.
+  - Make sure to follow steps described [here](https://developers.google.com/calendar/quickstart/python)
+  to be able to use Google Calendar API. We recommend using your
+  personal gmail account for this script to avoid any unnecessary sharing of corporate
+  information.
+  - Run the script to create and save your authorsation token in the `token.pickle` file.
+  This will automatically open your browser and prompt you to authorise read and write
+  access. It will also create a test event for verification.
+  ``` bash
+  python gcal/create_events.py --email-ids eid1@gmail.com eid2@workemail.com --force-create-token
+  ```
 - Inside `user_groups` directory create yaml file for your team `<team_name>.yaml`. Copy&paste here the content from `user_group_template.txt`. Fill out the fields using the same format.
 - IMPORTANT: You need to manually create google meet rooms with corporate account so that other people in that corporation can join the meeting without any approvals.
-- Run `python generate_watercoolers.py` to generate watercoolers for all user groups in `user_groups` folder.
-
-**Note:** When running the script for the first time, your browser will automatically open an authorisation window and prompt you to authorise read and write access. This will create a `token.pickle` file. For subsequent runs, the script will simply read the cached token and you would not need a browser.
-
+- Run `python generate_watercoolers.py` to generate watercoolers for all user groups in
+`user_groups` folder. This script will read the cached token from the previous steps
+and you would not need a browser.
 
 ## Scheduling on cron
 The following example schedules the watercoolers every week on Mondays at 5am.
 ``` bash
+$ crontab -e
+
 0 5 * * MON /home/virtualenv/bin/python /home/watercooler/generate_watercoolers.py
 ```

--- a/gcal/create_events.py
+++ b/gcal/create_events.py
@@ -1,3 +1,7 @@
+"""This module/script contains functions to create gcal auth tokens and events.
+
+See README for usage.
+"""
 from __future__ import print_function
 import argparse
 import datetime

--- a/gcal/create_events.py
+++ b/gcal/create_events.py
@@ -1,29 +1,51 @@
 from __future__ import print_function
+import argparse
 import datetime
+import logging
+import os.path
 import pathlib
 import pickle
-import os.path
-from datetime import datetime
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from typing import List
+
+
+logging.basicConfig(level=logging.INFO)
+
 
 # If modifying these scopes, delete the file token.pickle.
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
 def create_service(creds_dir: pathlib.PosixPath):
-    creds = None
+    return build(
+        serviceName="calendar",
+        version="v3",
+        credentials=load_or_create_creds(creds_dir=creds_dir),
+    )
+
+
+def load_or_create_creds(creds_dir: pathlib.PosixPath, force_create: bool = False):
+    """Either loads or creates your google calendar api token.
+
+    :param creds_dir: The directory where the pickle token is to be saved.
+    :param force_create: If set a new token will be created and
+        saved regardless of if a token already exists.
+    """
     # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
     token_fl = creds_dir / "token.pickle"
-    if os.path.exists(token_fl):
+    if not force_create and os.path.exists(token_fl):
+        logging.info("Pickled token file exists and we are loading from it.")
         with open(token_fl, "rb") as token:
             creds = pickle.load(token)
+    else:
+        creds = None
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
+        logging.info("Creating a new pickled token file.")
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
@@ -33,9 +55,9 @@ def create_service(creds_dir: pathlib.PosixPath):
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open(token_fl, "wb") as token:
+            logging.info("Writing to the pickled token file.")
             pickle.dump(creds, token)
-
-    return build("calendar", "v3", credentials=creds)
+    return creds
 
 
 def create_event(
@@ -72,17 +94,52 @@ def create_event(
         .insert(calendarId="primary", body=event)
         .execute()
     )
-    print(f"Event created: {(created_event.get('htmlLink'))}")
+    logging.info(f"Event created: {(created_event.get('htmlLink'))}")
 
 
-if __name__ == "__main__":
-    print("Creating test event that starts now...")
-    now = datetime.now()
-    from datetime import timedelta
+########################################################################################
+#                                       TESTING
+########################################################################################
 
+
+def test():
+    logging.info("Creating test event that starts now...")
+    cmd_opts = _parse_args()
+    creds_dir = pathlib.Path(__file__).parent.absolute() / "../"
+    load_or_create_creds(creds_dir=creds_dir, force_create=cmd_opts.force_create_token)
+    now = datetime.datetime.now()
     create_event(
         summary="Test event",
         start_time=now,
-        end_time=now + timedelta(hours=1),
-        guest_emails=["ulugbekuulutemirlan@gmail.com", "temirlan@yelp.com"],
+        end_time=now + datetime.timedelta(hours=1),
+        guest_emails=cmd_opts.email_ids,
+        creds_dir=creds_dir,
     )
+
+
+def _parse_args():
+    """Parse command line arguments"""
+    cmd_parser = argparse.ArgumentParser(description="Script to test event creation.",)
+    cmd_parser.add_argument(
+        "--email-ids",
+        dest="email_ids",
+        type=str,
+        nargs="+",
+        help=("List of email ids whom should be included in the event."),
+        required=True,
+    )
+    cmd_parser.add_argument(
+        "--force-create-token",
+        dest="force_create_token",
+        help=(
+            "Whether to create and save a new token regardless of if one exists "
+            "already.",
+        ),
+        default=False,
+        action="store_true",
+    )
+    return cmd_parser.parse_args()
+
+
+if __name__ == "__main__":
+    test()

--- a/generate_watercoolers.py
+++ b/generate_watercoolers.py
@@ -28,14 +28,12 @@ def generate_watercoolers():
     for yaml_file in yaml_files:
         print(colored(f"Reading file {yaml_file}...", "magenta"))
         generate_watercoolers_for_user_group(
-            user_group_file_name=yaml_file,
-            script_dir=script_dir,
+            user_group_file_name=yaml_file, script_dir=script_dir,
         )
 
 
 def generate_watercoolers_for_user_group(
-    user_group_file_name: str,
-    script_dir: pathlib.PosixPath,
+    user_group_file_name: str, script_dir: pathlib.PosixPath,
 ):
     # Load topics
     with open(script_dir / "topics.txt", "r") as topics_file:


### PR DESCRIPTION
## Background
We need an easy setup script that can help users create and save their auth tokens but also verify if the event creation works as expected. With that in mind, I have updated the `create_events.py` module/script to do just that.

## Changes
### r1
- Refactored the token creation out of the `create_service` function.
- Allowed for a force creation of the token, even if it already exists.
- Used `logging` instead of print statements.
- Added cmd line arguments to pass test emails and forcing token creation.
- Updated `README.md`.